### PR TITLE
feat: extract footer into reusable component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import './App.css'
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import NavBar from './components/NavBar';
+import Footer from './components/Footer';
 import Startseite from './pages/Startseite.tsx';
 import Leistungen from './pages/Leistungen';
 import Vorteile from './pages/Vorteile.tsx';
@@ -20,8 +21,10 @@ function App() {
         <Route path="/beratung" element={<Beratung />} />
         <Route path="/metallform" element={<MetallForm />} />
       </Routes>
+      <Footer />
     </Router>
   );
-} 
+}
 
 export default App
+

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -1,0 +1,20 @@
+/* Footer.css */
+.footer {
+  background: #2e2e2e;
+  color: #cccccc;
+  padding: 2rem 0;
+}
+.footer-inner {
+  width: 90%;
+  max-width: 1200px;
+  margin: 0 auto;
+  text-align: center;
+}
+.footer a {
+  color: #cccccc;
+  text-decoration: none;
+  margin: 0 0.5rem;
+}
+.footer a:hover {
+  color: #ffffff;
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,14 @@
+import './Footer.css';
+
+const Footer = () => {
+  return (
+    <footer className="footer">
+      <div className="footer-inner">
+        <p>© 2025 MetallForm GmbH. Alle Rechte vorbehalten.</p>
+        <p><a href="#impressum">Impressum</a> | <a href="#datenschutz">Datenschutz</a></p>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/pages/Startseite.css
+++ b/src/pages/Startseite.css
@@ -69,21 +69,3 @@
   font-size: 1rem;
   color: #555555;
 }
-
-/* Footer */
-.footer {
-  background: #2e2e2e;
-  color: #cccccc;
-  padding: 2rem 0;
-}
-.footer-inner {
-  text-align: center;
-}
-.footer a {
-  color: #cccccc;
-  text-decoration: none;
-  margin: 0 0.5rem;
-}
-.footer a:hover {
-  color: #ffffff;
-}

--- a/src/pages/Startseite.tsx
+++ b/src/pages/Startseite.tsx
@@ -35,15 +35,8 @@ const Startseite = () => {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="footer">
-        <div className="container footer-inner">
-          <p>© 2025 MetallForm GmbH. Alle Rechte vorbehalten.</p>
-          <p><a href="#impressum">Impressum</a> | <a href="#datenschutz">Datenschutz</a></p>
-        </div>
-      </footer>
-    </div>
-  );
-};
+      </div>
+    );
+  };
 
 export default Startseite;


### PR DESCRIPTION
## Summary
- create dedicated `Footer` component with styling
- render global footer in `App` so all routes include it
- remove previously hard-coded footer from start page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f756c2c508324a784c042e9d4f496