### PR TITLE
Add service, benefit, and consultation sections with sticky footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,15 +13,19 @@ import MetallForm from './pages/MetallForm.tsx';
 function App() {
   return (
     <Router>
-      <NavBar />
-      <Routes>
-        <Route path="/" element={<Startseite />} />
-        <Route path="/leistungen" element={<Leistungen />} />
-        <Route path="/vorteile" element={<Vorteile />} />
-        <Route path="/beratung" element={<Beratung />} />
-        <Route path="/metallform" element={<MetallForm />} />
-      </Routes>
-      <Footer />
+      <div className="min-h-screen flex flex-col">
+        <NavBar />
+        <main className="flex-grow">
+          <Routes>
+            <Route path="/" element={<Startseite />} />
+            <Route path="/leistungen" element={<Leistungen />} />
+            <Route path="/vorteile" element={<Vorteile />} />
+            <Route path="/beratung" element={<Beratung />} />
+            <Route path="/metallform" element={<MetallForm />} />
+          </Routes>
+        </main>
+        <Footer />
+      </div>
     </Router>
   );
 }

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -1,20 +1,2 @@
-/* Footer.css */
-.footer {
-  background: #2e2e2e;
-  color: #cccccc;
-  padding: 2rem 0;
-}
-.footer-inner {
-  width: 90%;
-  max-width: 1200px;
-  margin: 0 auto;
-  text-align: center;
-}
-.footer a {
-  color: #cccccc;
-  text-decoration: none;
-  margin: 0 0.5rem;
-}
-.footer a:hover {
-  color: #ffffff;
-}
+/* Placeholder for future footer styles */
+

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,14 +1,33 @@
 import './Footer.css';
+import { FaFacebookF, FaInstagram, FaLinkedinIn } from 'react-icons/fa';
 
 const Footer = () => {
   return (
-    <footer className="footer">
-      <div className="footer-inner">
-        <p>© 2025 MetallForm GmbH. Alle Rechte vorbehalten.</p>
-        <p><a href="#impressum">Impressum</a> | <a href="#datenschutz">Datenschutz</a></p>
+    <footer className="p-8" id="footer">
+      <div className="flex flex-col items-center gap-4">
+        <address className="not-italic text-center">
+          Musterstraße 1<br />12345 Musterstadt<br />
+          <a href="#anfahrt">Anfahrt</a>
+        </address>
+        <div className="flex gap-4">
+          <a href="#">
+            <FaFacebookF />
+          </a>
+          <a href="#">
+            <FaInstagram />
+          </a>
+          <a href="#">
+            <FaLinkedinIn />
+          </a>
+        </div>
+        <nav className="flex gap-4">
+          <a href="#impressum">Impressum</a>
+          <a href="#datenschutz">Datenschutz</a>
+        </nav>
       </div>
     </footer>
   );
 };
 
 export default Footer;
+

--- a/src/pages/Beratung.css
+++ b/src/pages/Beratung.css
@@ -1,0 +1,2 @@
+/* Platzhalter für zukünftige Styles der Beratung-Section */
+

--- a/src/pages/Beratung.tsx
+++ b/src/pages/Beratung.tsx
@@ -1,8 +1,57 @@
-export default function Beratung() {
+import './Beratung.css';
+
+const steps = [
+  'Anfrage',
+  'Vor-Ort-Termin',
+  '3D-Planung & Angebot',
+  'Fertigung & Montage',
+];
+
+const Timeline = () => (
+  <ol className="flex flex-wrap gap-4 justify-between">
+    {steps.map((step, index) => (
+      <li key={step} className="flex items-center gap-2">
+        <span>{step}</span>
+        {index < steps.length - 1 && <span>→</span>}
+      </li>
+    ))}
+  </ol>
+);
+
+export default function BeratungSection() {
   return (
-    <section>
-      <h1>Beratung</h1>
-      <p>Unsere Beratung für Ihr Projekt.</p>
+    <section className="p-8" id="beratung">
+      <h2 className="text-2xl mb-4">Beratung</h2>
+      <Timeline />
+      <form className="grid gap-4 mt-8">
+        <div className="grid gap-2">
+          <label htmlFor="name">Name</label>
+          <input id="name" type="text" className="p-2" />
+        </div>
+        <div className="grid gap-2">
+          <label htmlFor="email">E-Mail</label>
+          <input id="email" type="email" className="p-2" />
+        </div>
+        <div className="grid gap-2">
+          <label htmlFor="phone">Telefon</label>
+          <input id="phone" type="tel" className="p-2" />
+        </div>
+        <div className="grid gap-2">
+          <label htmlFor="service">Leistung</label>
+          <select id="service" className="p-2">
+            <option>Stahlkonstruktionen</option>
+            <option>Schweißarbeiten</option>
+            <option>Treppen & Geländer</option>
+            <option>Fahrzeugbau</option>
+          </select>
+        </div>
+        <div className="grid gap-2">
+          <label htmlFor="message">Freitext</label>
+          <textarea id="message" rows={4} className="p-2" />
+        </div>
+        <button type="submit" className="p-2">Absenden</button>
+      </form>
     </section>
   );
 }
+

--- a/src/pages/Leistungen.css
+++ b/src/pages/Leistungen.css
@@ -1,0 +1,2 @@
+/* Platzhalter für zukünftige Styles der Leistungen-Section */
+

--- a/src/pages/Leistungen.tsx
+++ b/src/pages/Leistungen.tsx
@@ -1,8 +1,64 @@
-export default function Leistungen() {
+import './Leistungen.css';
+import { FaIndustry, FaWrench, FaStream, FaTruck } from 'react-icons/fa';
+import type { ReactNode } from 'react';
+
+interface Service {
+  icon: ReactNode;
+  title: string;
+  text: string;
+  items: string[];
+}
+
+const services: Service[] = [
+  {
+    icon: <FaIndustry />,
+    title: 'Stahlkonstruktionen',
+    text: 'Individuelle Lösungen aus Stahl für jedes Projekt.',
+    items: ['Projekt A', 'Projekt B', 'Projekt C'],
+  },
+  {
+    icon: <FaWrench />,
+    title: 'Schweißarbeiten',
+    text: 'Präzise Schweißnähte für hohe Belastungen.',
+    items: ['Arbeit A', 'Arbeit B', 'Arbeit C'],
+  },
+  {
+    icon: <FaStream />,
+    title: 'Treppen & Geländer',
+    text: 'Sichere und formschöne Aufstiege.',
+    items: ['Treppenprojekt 1', 'Geländerprojekt 2', 'Treppenprojekt 3'],
+  },
+  {
+    icon: <FaTruck />,
+    title: 'Fahrzeugbau',
+    text: 'Aufbauten und Anpassungen nach Wunsch.',
+    items: ['Fahrzeug A', 'Fahrzeug B', 'Fahrzeug C'],
+  },
+];
+
+const ServiceCard = ({ icon, title, text, items }: Service) => (
+  <article className="p-4 border rounded flex flex-col gap-2">
+    <div className="text-3xl">{icon}</div>
+    <h3 className="text-xl">{title}</h3>
+    <p>{text}</p>
+    <ul className="list-disc pl-5">
+      {items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  </article>
+);
+
+export default function LeistungenSection() {
   return (
-    <section>
-      <h1>Leistungen</h1>
-      <p>Unsere Leistungen im Überblick.</p>
+    <section className="p-8" id="leistungen">
+      <h2 className="text-2xl mb-4">Leistungen</h2>
+      <div className="grid gap-8 md:grid-cols-2">
+        {services.map((service) => (
+          <ServiceCard key={service.title} {...service} />
+        ))}
+      </div>
     </section>
   );
 }
+

--- a/src/pages/Vorteile.css
+++ b/src/pages/Vorteile.css
@@ -1,0 +1,2 @@
+/* Platzhalter für zukünftige Styles der Vorteile-Section */
+

--- a/src/pages/Vorteile.tsx
+++ b/src/pages/Vorteile.tsx
@@ -1,8 +1,54 @@
-export default function Vorteile() {
+import './Vorteile.css';
+import { FaUserTie, FaClock, FaLeaf, FaBalanceScale } from 'react-icons/fa';
+import type { ReactNode } from 'react';
+
+interface Benefit {
+  icon: ReactNode;
+  title: string;
+  text: string;
+}
+
+const benefits: Benefit[] = [
+  {
+    icon: <FaUserTie />,
+    title: 'Individuelle Beratung',
+    text: 'Persönliche Betreuung von Anfang an.',
+  },
+  {
+    icon: <FaClock />,
+    title: 'Kurze Lieferzeiten',
+    text: 'Effiziente Abläufe für schnelle Ergebnisse.',
+  },
+  {
+    icon: <FaLeaf />,
+    title: 'Nachhaltige Materialien',
+    text: 'Ressourcenschonender Einsatz von Rohstoffen.',
+  },
+  {
+    icon: <FaBalanceScale />,
+    title: 'Faire Preise',
+    text: 'Transparente Kalkulation ohne Überraschungen.',
+  },
+];
+
+const BenefitCard = ({ icon, title, text }: Benefit) => (
+  <article className="p-4 border rounded flex flex-col items-start gap-2">
+    <div className="text-3xl">{icon}</div>
+    <h3 className="text-xl">{title}</h3>
+    <p>{text}</p>
+  </article>
+);
+
+export default function VorteileSection() {
   return (
-    <section>
-      <h1>Vorteile</h1>
-      <p>Darum sollten Sie uns wählen.</p>
+    <section className="p-8" id="vorteile">
+      <h2 className="text-2xl mb-4">Vorteile</h2>
+      <div className="grid gap-8 md:grid-cols-2">
+        {benefits.map((benefit) => (
+          <BenefitCard key={benefit.title} {...benefit} />
+        ))}
+      </div>
     </section>
   );
 }
+


### PR DESCRIPTION
## Summary
- add detailed Leistungen, Vorteile, and Beratung sections using semantic markup and Tailwind layout utilities
- rebuild footer with address placeholder, social links, and legal references
- ensure layout uses flex column so footer sticks to page bottom

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f958bd74883249cf45ad71ae0d4d9