### PR TITLE
Organize Leistungen categories and link offer CTA

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -22,7 +22,7 @@ const NavBar = () => {
           <li><Link to="/metallform" onClick={closeMenu} className="nav-link">MetallForm</Link></li>
         </ul>
         <div className="actions">
-          <Link to="/" className="cta-button">Zum Angebot</Link>
+          <Link to="/beratung" className="cta-button">Zum Angebot</Link>
           <a href="tel:0721*******" className="phone-link"><FaPhoneAlt />0721 *******</a>
           <button onClick={toggleMenu} className="menu-button">
             {menuOpen ? <FaTimes /> : <FaBars />}

--- a/src/pages/Beratung.css
+++ b/src/pages/Beratung.css
@@ -1,2 +1,57 @@
-/* Platzhalter für zukünftige Styles der Beratung-Section */
+.beratung-section {
+  padding: 2rem;
+}
+
+.beratung-section h2 {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.timeline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  list-style: none;
+  padding: 0;
+}
+
+.timeline li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.beratung-form {
+  display: grid;
+  gap: 1rem;
+  max-width: 500px;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.submit-button {
+  padding: 0.75rem;
+  background: #ff6a00;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.submit-button:hover {
+  background: #e65f00;
+}
 

--- a/src/pages/Beratung.tsx
+++ b/src/pages/Beratung.tsx
@@ -8,11 +8,11 @@ const steps = [
 ];
 
 const Timeline = () => (
-  <ol className="flex flex-wrap gap-4 justify-between">
+  <ol className="timeline">
     {steps.map((step, index) => (
-      <li key={step} className="flex items-center gap-2">
+      <li key={step}>
         <span>{step}</span>
-        {index < steps.length - 1 && <span>→</span>}
+        {index < steps.length - 1 && <span className="arrow">→</span>}
       </li>
     ))}
   </ol>
@@ -20,36 +20,36 @@ const Timeline = () => (
 
 export default function BeratungSection() {
   return (
-    <section className="p-8" id="beratung">
-      <h2 className="text-2xl mb-4">Beratung</h2>
+    <section className="beratung-section" id="beratung">
+      <h2>Beratung</h2>
       <Timeline />
-      <form className="grid gap-4 mt-8">
-        <div className="grid gap-2">
+      <form className="beratung-form">
+        <div className="form-field">
           <label htmlFor="name">Name</label>
-          <input id="name" type="text" className="p-2" />
+          <input id="name" type="text" />
         </div>
-        <div className="grid gap-2">
+        <div className="form-field">
           <label htmlFor="email">E-Mail</label>
-          <input id="email" type="email" className="p-2" />
+          <input id="email" type="email" />
         </div>
-        <div className="grid gap-2">
+        <div className="form-field">
           <label htmlFor="phone">Telefon</label>
-          <input id="phone" type="tel" className="p-2" />
+          <input id="phone" type="tel" />
         </div>
-        <div className="grid gap-2">
+        <div className="form-field">
           <label htmlFor="service">Leistung</label>
-          <select id="service" className="p-2">
+          <select id="service">
             <option>Stahlkonstruktionen</option>
             <option>Schweißarbeiten</option>
             <option>Treppen & Geländer</option>
             <option>Fahrzeugbau</option>
           </select>
         </div>
-        <div className="grid gap-2">
+        <div className="form-field">
           <label htmlFor="message">Freitext</label>
-          <textarea id="message" rows={4} className="p-2" />
+          <textarea id="message" rows={4} />
         </div>
-        <button type="submit" className="p-2">Absenden</button>
+        <button type="submit" className="submit-button">Absenden</button>
       </form>
     </section>
   );

--- a/src/pages/Leistungen.css
+++ b/src/pages/Leistungen.css
@@ -1,2 +1,31 @@
-/* Platzhalter für zukünftige Styles der Leistungen-Section */
+.leistungen-section {
+  padding: 2rem;
+}
+
+.leistungen-section h2 {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.category {
+  margin-bottom: 2rem;
+}
+
+.category h3 {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.image-grid img {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  object-fit: cover;
+}
 

--- a/src/pages/Leistungen.tsx
+++ b/src/pages/Leistungen.tsx
@@ -1,63 +1,55 @@
 import './Leistungen.css';
-import { FaIndustry, FaWrench, FaStream, FaTruck } from 'react-icons/fa';
-import type { ReactNode } from 'react';
 
-interface Service {
-  icon: ReactNode;
+interface Category {
   title: string;
-  text: string;
-  items: string[];
+  images: string[];
 }
 
-const services: Service[] = [
+const categories: Category[] = [
   {
-    icon: <FaIndustry />,
-    title: 'Stahlkonstruktionen',
-    text: 'Individuelle Lösungen aus Stahl für jedes Projekt.',
-    items: ['Projekt A', 'Projekt B', 'Projekt C'],
+    title: 'Tore',
+    images: ['/Tor_1.jpg', '/Tor_2.jpg', '/Tor_3.jpg'],
   },
   {
-    icon: <FaWrench />,
-    title: 'Schweißarbeiten',
-    text: 'Präzise Schweißnähte für hohe Belastungen.',
-    items: ['Arbeit A', 'Arbeit B', 'Arbeit C'],
+    title: 'Geländer',
+    images: ['/Geländer_1.jpg', '/Geländer_2.jpg', '/Geländer_3.jpg'],
   },
   {
-    icon: <FaStream />,
-    title: 'Treppen & Geländer',
-    text: 'Sichere und formschöne Aufstiege.',
-    items: ['Treppenprojekt 1', 'Geländerprojekt 2', 'Treppenprojekt 3'],
+    title: 'Treppen',
+    images: ['/Treppe_1.jpg', '/Treppe_2.jpg'],
   },
   {
-    icon: <FaTruck />,
-    title: 'Fahrzeugbau',
-    text: 'Aufbauten und Anpassungen nach Wunsch.',
-    items: ['Fahrzeug A', 'Fahrzeug B', 'Fahrzeug C'],
+    title: 'Vitrinen',
+    images: ['/Vitrinen_1.jpg', '/Vitrinen_2.jpg', '/Vitrinen_3.jpg'],
+  },
+  {
+    title: 'Sonstiges',
+    images: [
+      '/IMG-20250802-WA0009.jpg',
+      '/IMG-20250802-WA0014.jpg',
+      '/IMG-20250802-WA0016.jpg',
+    ],
   },
 ];
 
-const ServiceCard = ({ icon, title, text, items }: Service) => (
-  <article className="p-4 border rounded flex flex-col gap-2">
-    <div className="text-3xl">{icon}</div>
-    <h3 className="text-xl">{title}</h3>
-    <p>{text}</p>
-    <ul className="list-disc pl-5">
-      {items.map((item) => (
-        <li key={item}>{item}</li>
+const CategoryBlock = ({ title, images }: Category) => (
+  <div className="category">
+    <h3>{title}</h3>
+    <div className="image-grid">
+      {images.map((src) => (
+        <img key={src} src={src} alt={title} />
       ))}
-    </ul>
-  </article>
+    </div>
+  </div>
 );
 
 export default function LeistungenSection() {
   return (
-    <section className="p-8" id="leistungen">
-      <h2 className="text-2xl mb-4">Leistungen</h2>
-      <div className="grid gap-8 md:grid-cols-2">
-        {services.map((service) => (
-          <ServiceCard key={service.title} {...service} />
-        ))}
-      </div>
+    <section className="leistungen-section" id="leistungen">
+      <h2>Leistungen</h2>
+      {categories.map((category) => (
+        <CategoryBlock key={category.title} {...category} />
+      ))}
     </section>
   );
 }

--- a/src/pages/MetallForm.css
+++ b/src/pages/MetallForm.css
@@ -1,0 +1,9 @@
+.metallform-section {
+  padding: 2rem;
+}
+
+.metallform-section h1 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+

--- a/src/pages/MetallForm.tsx
+++ b/src/pages/MetallForm.tsx
@@ -1,6 +1,8 @@
+import './MetallForm.css';
+
 export default function MetallForm() {
   return (
-    <section>
+    <section className="metallform-section">
       <h1>MetallForm</h1>
       <p>Informationen über MetallForm.</p>
     </section>

--- a/src/pages/Startseite.tsx
+++ b/src/pages/Startseite.tsx
@@ -1,4 +1,5 @@
 import './Startseite.css';
+import { Link } from 'react-router-dom';
 
 /**
  * Startseite mit vollem Hintergrundbild und CTA
@@ -11,7 +12,7 @@ const Startseite = () => {
         <div className="container hero-content">
           <h2>Präzision in Stahl</h2>
           <p>Ihr Partner fürs Metallhandwerk – von der Idee bis zur Montage.</p>
-          <a href="#beratung" className="cta-button hero-cta">Jetzt Angebot anfragen</a>
+          <Link to="/beratung" className="cta-button hero-cta">Jetzt Angebot anfragen</Link>
         </div>
       </section>
 

--- a/src/pages/Vorteile.css
+++ b/src/pages/Vorteile.css
@@ -1,2 +1,28 @@
-/* Platzhalter für zukünftige Styles der Vorteile-Section */
+.vorteile-section {
+  padding: 2rem;
+}
+
+.vorteile-section h2 {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.benefit-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}
+
+.benefit-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.benefit-card .icon {
+  font-size: 2rem;
+}
 

--- a/src/pages/Vorteile.tsx
+++ b/src/pages/Vorteile.tsx
@@ -32,18 +32,18 @@ const benefits: Benefit[] = [
 ];
 
 const BenefitCard = ({ icon, title, text }: Benefit) => (
-  <article className="p-4 border rounded flex flex-col items-start gap-2">
-    <div className="text-3xl">{icon}</div>
-    <h3 className="text-xl">{title}</h3>
+  <article className="benefit-card">
+    <div className="icon">{icon}</div>
+    <h3>{title}</h3>
     <p>{text}</p>
   </article>
 );
 
 export default function VorteileSection() {
   return (
-    <section className="p-8" id="vorteile">
-      <h2 className="text-2xl mb-4">Vorteile</h2>
-      <div className="grid gap-8 md:grid-cols-2">
+    <section className="vorteile-section" id="vorteile">
+      <h2>Vorteile</h2>
+      <div className="benefit-grid">
         {benefits.map((benefit) => (
           <BenefitCard key={benefit.title} {...benefit} />
         ))}


### PR DESCRIPTION
## Summary
- Group service gallery into Tore, Geländer, Treppen, Vitrinen and Sonstiges with responsive image grids.
- Add dedicated CSS styling for all pages including Beratung, Vorteile and MetallForm.
- Point all offer request buttons and links to the Beratung page.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fc16348748324a297f0b8fdf5e148