### PR TITLE
refactor: redesign Leistungen section

### DIFF
--- a/src/pages/Leistungen.css
+++ b/src/pages/Leistungen.css
@@ -1,5 +1,7 @@
 .leistungen-section {
-  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
 }
 
 .leistungen-section h2 {
@@ -7,31 +9,89 @@
   margin-bottom: 1.5rem;
 }
 
-.category {
-  margin-bottom: 2rem;
-}
-
-.category h3 {
-  font-size: 1.5rem;
-  margin-bottom: 0.75rem;
-}
-
-.image-row {
+.service-area {
   display: flex;
-  align-items: center;
-  gap: 1rem;
+  gap: 2rem;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  border-radius: 8px;
+}
+
+.service-area.gray {
+  background-color: #f5f5f5;
+}
+
+.service-area.white {
+  background-color: #ffffff;
+}
+
+.service-text {
+  flex: 1;
+}
+
+.service-text h3 {
+  color: #0056b3;
   margin-bottom: 1rem;
 }
 
-.image-row img {
-  width: 200px;
-  height: 200px;
-  border-radius: 8px;
-  object-fit: cover;
+.service-text p {
+  color: #333333;
+  line-height: 1.6;
+  margin-bottom: 1rem;
 }
 
-.image-row p {
+.service-text ul {
+  list-style: none;
+  padding: 0;
   margin: 0;
 }
 
+.service-text ul li {
+  position: relative;
+  padding-left: 1rem;
+  margin-bottom: 0.5rem;
+}
 
+.service-text ul li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.6em;
+  width: 0.5rem;
+  height: 0.5rem;
+  background-color: #0056b3;
+  border-radius: 50%;
+  transform: translateY(-50%);
+}
+
+.service-images {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.service-images .main-image {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.service-images .thumbnail-row {
+  display: flex;
+  gap: 1rem;
+}
+
+.service-images .thumbnail-row img {
+  flex: 1;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+@media (max-width: 768px) {
+  .service-area {
+    flex-direction: column;
+  }
+}

--- a/src/pages/Leistungen.tsx
+++ b/src/pages/Leistungen.tsx
@@ -32,16 +32,33 @@ const categories: Category[] = [
   },
 ];
 
-const CategoryBlock = ({ title, images }: Category) => (
-  <div className="category">
-    <h3>{title}</h3>
-    {images.map((src, index) => (
-      <div key={src} className="image-row">
-        <img src={src} alt={`${title} Bild ${index + 1}`} />
-        <p>{`${title} Bild ${index + 1}`}</p>
-      </div>
-    ))}
+interface CategoryBlockProps extends Category {
+  variant: 'gray' | 'white';
+}
 
+const CategoryBlock = ({ title, images, variant }: CategoryBlockProps) => (
+  <div className={`service-area ${variant}`}>
+    <div className="service-text">
+      <h3>{title}</h3>
+    </div>
+    <div className="service-images">
+      {images[0] && (
+        <img
+          className="main-image"
+          src={images[0]}
+          alt={`${title} Bild 1`}
+        />
+      )}
+      <div className="thumbnail-row">
+        {images.slice(1, 5).map((src, index) => (
+          <img
+            key={src}
+            src={src}
+            alt={`${title} Bild ${index + 2}`}
+          />
+        ))}
+      </div>
+    </div>
   </div>
 );
 
@@ -49,8 +66,12 @@ export default function LeistungenSection() {
   return (
     <section className="leistungen-section" id="leistungen">
       <h2>Leistungen</h2>
-      {categories.map((category) => (
-        <CategoryBlock key={category.title} {...category} />
+      {categories.map((category, index) => (
+        <CategoryBlock
+          key={category.title}
+          {...category}
+          variant={index % 2 === 0 ? 'gray' : 'white'}
+        />
       ))}
     </section>
   );


### PR DESCRIPTION
## Summary
- redesign Leistungen page layout with centered wrapper and flexible service blocks
- style headings, lists, and image galleries with modern look and alternating backgrounds
- add responsive stacking for mobile viewports

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890b73fdcc483248b94dab353b8f3b0