### PR TITLE
refactor: redesign Leistungen section

### DIFF
--- a/src/pages/Leistungen.css
+++ b/src/pages/Leistungen.css
@@ -1,37 +1,91 @@
 .leistungen-section {
-  padding: 2rem;
+  width: 100%;
 }
 
-.leistungen-section h2 {
+.leistungen-header {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.leistungen-header h2 {
   font-size: 2rem;
   margin-bottom: 1.5rem;
 }
 
-.category {
-  margin-bottom: 2rem;
+.service-area {
+  width: 100%;
+  padding: 2rem 0;
 }
 
-.category h3 {
-  font-size: 1.5rem;
-  margin-bottom: 0.75rem;
+.service-area.gray {
+  background-color: #f5f5f5;
 }
 
-.image-row {
+.service-area.white {
+  background-color: #ffffff;
+}
+
+.service-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.service-main {
   display: flex;
-  align-items: center;
-  gap: 1rem;
+  gap: 2rem;
   margin-bottom: 1rem;
 }
 
-.image-row img {
-  width: 200px;
-  height: 200px;
-  border-radius: 8px;
+.main-image {
+  width: 400px;
+  height: 300px;
   object-fit: cover;
+  border-radius: 8px;
 }
 
-.image-row p {
-  margin: 0;
+.service-text {
+  flex: 1;
 }
 
+.service-text h3 {
+  color: #0056b3;
+  margin-bottom: 1rem;
+}
 
+.service-text p {
+  color: #333333;
+  line-height: 1.6;
+}
+
+.thumbnail-row {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.thumbnail-row img {
+  width: 200px;
+  height: 150px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+@media (max-width: 768px) {
+  .service-main {
+    flex-direction: column;
+  }
+
+  .main-image {
+    width: 100%;
+  }
+
+  .thumbnail-row {
+    flex-wrap: wrap;
+  }
+
+  .thumbnail-row img {
+    width: calc(50% - 0.5rem);
+  }
+}

--- a/src/pages/Leistungen.tsx
+++ b/src/pages/Leistungen.tsx
@@ -2,28 +2,34 @@ import './Leistungen.css';
 
 interface Category {
   title: string;
+  description: string;
   images: string[];
 }
 
 const categories: Category[] = [
   {
     title: 'Tore',
+    description: 'Individuelle Tore aus langlebigem Metall.',
     images: ['/Tor_1.jpg', '/Tor_2.jpg', '/Tor_3.jpg'],
   },
   {
     title: 'Geländer',
+    description: 'Stabile Geländer für Innen- und Außenbereiche.',
     images: ['/Geländer_1.jpg', '/Geländer_2.jpg', '/Geländer_3.jpg'],
   },
   {
     title: 'Treppen',
+    description: 'Maßgeschneiderte Metalltreppen für jeden Bedarf.',
     images: ['/Treppe_1.jpg', '/Treppe_2.jpg'],
   },
   {
     title: 'Vitrinen',
+    description: 'Elegante Vitrinen zur Präsentation besonderer Stücke.',
     images: ['/Vitrinen_1.jpg', '/Vitrinen_2.jpg', '/Vitrinen_3.jpg'],
   },
   {
     title: 'Sonstiges',
+    description: 'Weitere individuelle Metallarbeiten auf Anfrage.',
     images: [
       '/IMG-20250802-WA0009.jpg',
       '/IMG-20250802-WA0014.jpg',
@@ -32,25 +38,51 @@ const categories: Category[] = [
   },
 ];
 
-const CategoryBlock = ({ title, images }: Category) => (
-  <div className="category">
-    <h3>{title}</h3>
-    {images.map((src, index) => (
-      <div key={src} className="image-row">
-        <img src={src} alt={`${title} Bild ${index + 1}`} />
-        <p>{`${title} Bild ${index + 1}`}</p>
-      </div>
-    ))}
+interface CategoryBlockProps extends Category {
+  variant: 'gray' | 'white';
+}
 
+const CategoryBlock = ({ title, description, images, variant }: CategoryBlockProps) => (
+  <div className={`service-area ${variant}`}>
+    <div className="service-inner">
+      <div className="service-main">
+        {images[0] && (
+          <img
+            className="main-image"
+            src={images[0]}
+            alt={`${title} Bild 1`}
+          />
+        )}
+        <div className="service-text">
+          <h3>{title}</h3>
+          <p>{description}</p>
+        </div>
+      </div>
+      <div className="thumbnail-row">
+        {images.slice(1, 5).map((src, index) => (
+          <img
+            key={src}
+            src={src}
+            alt={`${title} Bild ${index + 2}`}
+          />
+        ))}
+      </div>
+    </div>
   </div>
 );
 
 export default function LeistungenSection() {
   return (
     <section className="leistungen-section" id="leistungen">
-      <h2>Leistungen</h2>
-      {categories.map((category) => (
-        <CategoryBlock key={category.title} {...category} />
+      <div className="leistungen-header">
+        <h2>Leistungen</h2>
+      </div>
+      {categories.map((category, index) => (
+        <CategoryBlock
+          key={category.title}
+          {...category}
+          variant={index % 2 === 0 ? 'gray' : 'white'}
+        />
       ))}
     </section>
   );


### PR DESCRIPTION
## Summary
- stretch alternating backgrounds full width while keeping inner content centered
- place main image left of text with fixed-size thumbnails below each service block
- add descriptions to category data for richer content

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890b73fdcc483248b94dab353b8f3b0