### PR TITLE
Use images for services and fullscreen hero

### DIFF
--- a/src/pages/Startseite.css
+++ b/src/pages/Startseite.css
@@ -11,12 +11,13 @@
   position: relative;
   overflow: hidden;
   display: flex;        /* oder flex, wenn du das Centering brauchst */
+  height: 100vh;
 }
 .hero__img {
   width: 100%;
-  height: 75%;
+  height: 100%;
   display: block;        /* entfernt evtl. unerwünschte inline-Spacing */
-  object-fit: cover; 
+  object-fit: cover;
   filter: brightness(0.5);    /* falls der Container doch mal begrenzt wird */
 }
 
@@ -25,7 +26,7 @@
   top: 0;
   left: 0;
   width: 100%;
-  height: 75%;
+  height: 100%;
   object-fit: cover;
 }
 .hero-overlay {
@@ -33,9 +34,9 @@
 }
 .hero__content {
   position: absolute;
-  top: 25%;              /* 25 % von der Oberkante der Hero-Section */
-  left: 50%;             /* zentriert horizontal */
-  transform: translateX(-50%);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   z-index: 2;
   max-width: 800px;
   border-radius: 8px;
@@ -67,7 +68,7 @@
 
 /* Features */
 .features {
-  padding: 4rem 0;
+  padding: 4rem var(--spacing);
   text-align: center;
   background-color: var(--color-bg); /* weiß */
 }
@@ -83,16 +84,13 @@
   gap: 2rem;
 }
 .feature {
-  background: rgba(0, 0, 0, 0.05);
   padding: 2rem;
   border-radius: 0.5rem;
-  transition: background 0.3s;
 }
-.feature:hover {
-  background: rgba(0, 0, 0, 0.1);
-}
-.feature__icon {
-  font-size: 2.5rem;
+.feature__img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
   margin-bottom: 1rem;
 }
 .feature h3 {

--- a/src/pages/Startseite.tsx
+++ b/src/pages/Startseite.tsx
@@ -25,31 +25,31 @@ const Hero: React.FC = () => (
 const Features: React.FC = () => {
   const items = [
     {
-      icon: '🔧',
+      img: '/Geländer_1.jpg',
       title: 'Individuelle Bauelemente',
       text: 'Planung und Fertigung von Treppen, Geländern, Balkonen und Überdachungen – passgenau auf Ihre Anforderungen abgestimmt',
     },
     {
-      icon: '⚙️',
+      img: '/Treppe_1.jpg',
       title: 'Präzisions-Schweiß- & Blechbearbeitung',
       text: 'Sonderanfertigungen aus Stahl, Edelstahl und Aluminium: effizient geschweißt, exakt zugeschnitten und oberflächenveredelt.',
     },
     {
-      icon: '⏱️',
+      img: '/Tor_1.jpg',
       title: 'Montage, Wartung & Reparatur',
       text: 'Fachgerechte Installation, Instandhaltung und punktuelle Reparaturen Ihrer Metallkonstruktionen – für dauerhafte Sicherheit und Funktion.',
     },
   ];
 
   return (
-    <section className="features container">
+    <section className="features">
       <h2>Unsere Dienstleistungen</h2>
       <div className="features__intro">
       </div>
       <div className="features__grid">
         {items.map((f, i) => (
           <div key={i} className="feature">
-            <div className="feature__icon">{f.icon}</div>
+            <img src={f.img} alt={f.title} className="feature__img" />
             <h3>{f.title}</h3>
             <p>{f.text}</p>
           </div>


### PR DESCRIPTION
## Summary
- Replace services icons with images and drop card background
- Allow services section to span full width
- Make hero image fill the viewport height

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689482d211c48324bc5b25d0114c1fe7