### PR TITLE
Enable snap scrolling on services page

### DIFF
--- a/src/pages/Leistungen.css
+++ b/src/pages/Leistungen.css
@@ -11,6 +11,9 @@
 .service-area {
   width: 100%;
   padding: 2rem 0;
+  height: 100vh;
+  scroll-snap-align: start;
+  box-sizing: border-box;
 }
 
 .service-area.gray {
@@ -25,23 +28,32 @@
   max-width: 1200px;
   margin: 0 auto;
   padding: 0 1rem;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .service-main {
   display: flex;
   gap: 2rem;
   margin-bottom: 1rem;
+  flex: 1;
+  align-items: center;
 }
 
 .main-image {
-  width: 400px;
-  height: 300px;
+  flex: 1;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   border-radius: 8px;
 }
 
 .service-text {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .service-text h3 {
@@ -74,6 +86,7 @@
 
   .main-image {
     width: 100%;
+    height: 50vh;
   }
 
   .thumbnail-row {

--- a/src/pages/Leistungen.tsx
+++ b/src/pages/Leistungen.tsx
@@ -76,8 +76,11 @@ const CategoryBlock = ({ title, description, images, variant }: CategoryBlockPro
 
 export default function LeistungenSection() {
   return (
-    <section className="leistungen-section" id="leistungen">
-
+    <section
+      className="leistungen-section"
+      id="leistungen"
+      style={{ scrollSnapType: 'y mandatory', overflowY: 'scroll', height: '100vh' }}
+    >
       {categories.map((category, index) => (
         <CategoryBlock
           key={category.title}


### PR DESCRIPTION
## Summary
- enable scroll snapping container for Leistungen section
- make each service area full-height with centered flex layout and cover images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894b1b91b00832499313d54a6c4b1c0