### PR TITLE
Limit page scroll to app content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -17,11 +17,13 @@ html, body {
 .app {
   display: flex;
   flex-direction: column;
-  min-height: 100vh; /* volle Viewport-Höhe */
+  height: 100vh; /* volle Viewport-Höhe */
+  overflow: hidden;
 }
 
 .app__content {
   flex: 1; /* füllt den verfügbaren Raum */
+  overflow-y: auto;
 }
 
 /* Bestehende Styles beibehalten */

--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,7 @@ h6 {
 html, body, #root {
   width: 100%;
   height: 100%;
-  overflow-x: hidden;
+  overflow: hidden;
   background-color: var(--color-bg);
   color: var(--color-text);
 }


### PR DESCRIPTION
## Summary
- hide overflow on `html`, `body`, and `#root` to stop page scrolling
- set `.app` container to fixed height and hide its overflow while allowing `.app__content` to scroll
- verified scroll-snap settings remain on the Startseite

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894c2ca8c4883248ec256b47c6b63f6