### PR TITLE
Remove scroll snapping styles

### DIFF
--- a/src/pages/Leistungen.css
+++ b/src/pages/Leistungen.css
@@ -19,7 +19,6 @@ img {
   width: 100%;
   padding: 2rem 0;
   height: 100vh;
-  scroll-snap-align: start;
   box-sizing: border-box;
 }
 

--- a/src/pages/Leistungen.tsx
+++ b/src/pages/Leistungen.tsx
@@ -79,7 +79,7 @@ export default function LeistungenSection() {
     <section
       className="leistungen-section"
       id="leistungen"
-      style={{ scrollSnapType: 'y mandatory', overflowY: 'scroll', height: '100vh' }}
+      style={{ overflowY: 'scroll', height: '100vh' }}
     >
       {categories.map((category, index) => (
         <CategoryBlock

--- a/src/pages/Startseite.css
+++ b/src/pages/Startseite.css
@@ -14,16 +14,14 @@ img {
   object-fit: cover;
 }
 
-/* Scroll Snap Container */
+/* Startseite Container */
 .startseite {
   height: 100vh;               /* volle Höhe */
   overflow-y: auto;            /* macht scrollbar */
-  scroll-snap-type: y mandatory;
 }
 
 .section{
-  scroll-snap-align: start;
-  height: 100vh; 
+  height: 100vh;
 }
 
 /* Hero */


### PR DESCRIPTION
## Summary
- remove scroll snap settings from Startseite page
- drop scroll snap usage from Leistungen page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894c4b7d4408324a9344bbc591d7c15