### PR TITLE
Fix double scrollbars by removing nested overflow

### DIFF
--- a/src/pages/Leistungen.tsx
+++ b/src/pages/Leistungen.tsx
@@ -79,7 +79,6 @@ export default function LeistungenSection() {
     <section
       className="leistungen-section"
       id="leistungen"
-      style={{ overflowY: 'scroll', height: '100vh' }}
     >
       {categories.map((category, index) => (
         <CategoryBlock

--- a/src/pages/Startseite.css
+++ b/src/pages/Startseite.css
@@ -16,8 +16,7 @@ img {
 
 /* Startseite Container */
 .startseite {
-  height: 100vh;               /* volle Höhe */
-  overflow-y: auto;            /* macht scrollbar */
+  min-height: 100vh;           /* mindestens volle Höhe, kein eigener Scroll */
 }
 
 .section{


### PR DESCRIPTION
## Summary
- remove redundant scroll handling from Startseite section
- drop inline scroll styles from Leistungen page to prevent nested scrollbars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894ff7b207c8324af64e0b7182b0c06