### PR TITLE
Remove overflow restrictions from App layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -17,13 +17,11 @@ html, body {
 .app {
   display: flex;
   flex-direction: column;
-  height: 100vh; /* volle Viewport-Höhe */
-  overflow: hidden;
+  min-height: 100vh; /* volle Viewport-Höhe */
 }
 
 .app__content {
   flex: 1; /* füllt den verfügbaren Raum */
-  overflow-y: auto;
 }
 
 /* Bestehende Styles beibehalten */


### PR DESCRIPTION
## Summary
- allow `.app` to expand beyond viewport by using `min-height: 100vh`
- drop overflow rules so content can scroll naturally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68959545dc2083249c9aa1ecd4dcf9f4