### PR TITLE
fix: enable mobile navbar toggle

### DIFF
--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -89,7 +89,7 @@
 /* ---------- Mobile Dropdown ---------- */
 @media (max-width: 767px) {
   /* Dropdown-Paneel */
-  .navbar__links.open {
+  .navbar--open .navbar__links {
     display: flex;
     flex-direction: column;
     position: fixed;
@@ -108,7 +108,7 @@
     display: none;
     pointer-events: none;
   }
-  .navbar__backdrop.open {
+  .navbar--open .navbar__backdrop {
     display: block;
     pointer-events: auto;
     position: fixed;

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -63,7 +63,7 @@ const NavBar = () => {
 
   return (
     <nav
-      ref={navRef as any}
+      ref={navRef}
       className={`navbar ${isOverHero ? 'navbar--over-hero' : 'navbar--solid'} ${menuOpen ? 'navbar--open' : ''}`}
     >
       <div className="navbar__container">
@@ -74,7 +74,8 @@ const NavBar = () => {
         {/* Desktop-Links / Mobile-Dropdown */}
         <ul
           id="mobile-menu"
-          className={`navbar__links ${menuOpen ? 'open' : ''}`}
+          className="navbar__links"
+          aria-hidden={!menuOpen}
         >
           <li><Link to="/" onClick={closeMenu} className="navbar__link">Home</Link></li>
           <li><Link to="/leistungen" onClick={closeMenu} className="navbar__link">Leistungen</Link></li>
@@ -97,7 +98,7 @@ const NavBar = () => {
 
       {/* Backdrop für Mobile-Menü */}
       <div
-        className={`navbar__backdrop ${menuOpen ? 'open' : ''}`}
+        className="navbar__backdrop"
         onClick={closeMenu}
         aria-hidden="true"
       />


### PR DESCRIPTION
## Summary
- ensure mobile menu opens by toggling styles based on `navbar--open`
- simplify NavBar markup and add accessibility flag for hidden state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run build` *(fails: TS6133 'React' is declared but its value is never read)*

------
https://chatgpt.com/codex/tasks/task_e_6899dee1617c8324a2d6a6cc290dc67f