### PR TITLE
Improve mobile scrolling and touch handling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,8 @@ html, body, #root {
   overflow-x: hidden;
   background-color: var(--color-bg);
   color: var(--color-text);
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
 }
 
 /* Angenehmes Scrollen global (optional) */
@@ -54,4 +56,24 @@ html {
 img, svg, video, canvas {
   display: block;           /* vermeidet Inline-Gaps */
   max-width: 100%;
+}
+
+/* Enable vertical panning for main sections */
+.page,
+.section,
+.hero,
+.features,
+.cta,
+.content-wrapper,
+.app,
+.app__content,
+.startseite,
+.fullpage,
+.fullpage-slide,
+.leistungen-page,
+.service-section,
+.about,
+.about__section,
+.navbar {
+  touch-action: pan-y;
 }

--- a/src/pages/Startseite.css
+++ b/src/pages/Startseite.css
@@ -10,13 +10,6 @@
   padding: var(--space-md);
   background-color: transparent;
 }
-
-img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
 .startseite { min-height: 100vh; }
 .section { height: 100vh; }
 
@@ -99,8 +92,9 @@ img {
   object-fit: cover;
   filter: brightness(0.3);
   z-index: 0;
+  pointer-events: none;
 }
-.hero-overlay { position: absolute; inset: 0; z-index: 1; }
+.hero-overlay { position: absolute; inset: 0; z-index: 1; pointer-events: none; }
 .hero__content {
   position: relative; z-index: 2;
   max-width: 800px; padding: var(--space-md);
@@ -185,7 +179,15 @@ img {
 .start-fullpage .app > footer { display: none !important; }
 
 /* Scrollbar ausblenden */
-html, body { background: transparent !important; margin: 0; padding: 0; height: 100%; overflow-y: scroll; }
+html, body {
+  background: transparent !important;
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
+}
 ::-webkit-scrollbar { display: none; }
 html { scrollbar-width: none; }
 


### PR DESCRIPTION
## Summary
- remove global `img` height rule and disable pointer events on hero background to prevent touch blocking
- add momentum scrolling and `touch-action: pan-y` across main sections for smoother mobile scrolling

## Testing
- `npm run lint` *(fails: Unexpected any in existing TS files)*

------
https://chatgpt.com/codex/tasks/task_e_6899e6514e548324b6c5cd2dd9eeb84f