### PR TITLE
Fix mobile scroll blocking on images

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -69,6 +69,7 @@ img, svg, video, canvas {
 .app__content,
 .startseite,
 .fullpage,
+.slides,
 .fullpage-slide,
 .leistungen-page,
 .service-section,
@@ -76,4 +77,22 @@ img, svg, video, canvas {
 .about__section,
 .navbar {
   touch-action: pan-y;
+}
+
+/* FIX: Images shouldn’t block scroll on mobile */
+.hero__img,
+.feature__img,
+.main-image,
+.cta__image,
+.thumbnail-row img {
+  touch-action: pan-y;
+  -webkit-user-drag: none;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* FIX: Decorative layers must not intercept touches */
+.hero__img,
+.hero-overlay {
+  pointer-events: none;
 }

--- a/src/pages/Beratung.tsx
+++ b/src/pages/Beratung.tsx
@@ -37,7 +37,7 @@ export default function BeratungSection() {
       });
 
       // Robust parsen (falls aus irgendeinem Grund kein valides JSON kommt)
-      let data: any = null;
+      let data: { ok?: boolean; error?: string } | null = null;
       const ct = res.headers.get('content-type') || '';
       if (ct.includes('application/json')) {
         data = await res.json();

--- a/src/pages/Leistungen.tsx
+++ b/src/pages/Leistungen.tsx
@@ -88,7 +88,7 @@ const CategoryBlock = ({ id, title, texts, images, showInlineFooter }: CategoryB
 
   return (
     <section
-      ref={sectionRef as any}
+      ref={sectionRef}
       id={id}
       className={`service-section reveal fullpage-slide ${showInlineFooter ? 'fullpage-slide--with-footer' : ''}`}
       aria-labelledby={`${id}-heading`}
@@ -189,14 +189,14 @@ export default function Leistungen() {
     };
 
     const onWheel = (e: WheelEvent) => {
-      if (isAnimating) return;
+      if (!isFullpage || isAnimating) return;
       if (Math.abs(e.deltaY) < 10) return;
       e.preventDefault();
       goTo(index + (e.deltaY > 0 ? 1 : -1));
     };
 
     const onKey = (e: KeyboardEvent) => {
-      if (isAnimating) return;
+      if (!isFullpage || isAnimating) return;
       if (['ArrowDown','PageDown',' '].includes(e.key)) { e.preventDefault(); goTo(index + 1); }
       if (['ArrowUp','PageUp'].includes(e.key))        { e.preventDefault(); goTo(index - 1); }
     };
@@ -204,7 +204,7 @@ export default function Leistungen() {
     window.addEventListener('wheel', onWheel, { passive: false });
     window.addEventListener('keydown', onKey);
     return () => {
-      window.removeEventListener('wheel', onWheel as any);
+      window.removeEventListener('wheel', onWheel);
       window.removeEventListener('keydown', onKey);
     };
   }, [isFullpage, index, isAnimating]);

--- a/src/pages/Startseite.tsx
+++ b/src/pages/Startseite.tsx
@@ -157,7 +157,7 @@ export default function Startseite() {
     const total = slides.length;
 
     const onWheel = (e: WheelEvent) => {
-      if (isAnimating) return;
+      if (!isFullpage || isAnimating) return;
       if (Math.abs(e.deltaY) < 10) return;
       e.preventDefault();
       setAnimating(true);
@@ -166,7 +166,7 @@ export default function Startseite() {
     };
 
     const onKey = (e: KeyboardEvent) => {
-      if (isAnimating) return;
+      if (!isFullpage || isAnimating) return;
       if (['ArrowDown','PageDown',' '].includes(e.key)) { e.preventDefault(); setIndex(i => Math.min(total - 1, i + 1)); setAnimating(true); window.setTimeout(()=>setAnimating(false),700); }
       if (['ArrowUp','PageUp'].includes(e.key))        { e.preventDefault(); setIndex(i => Math.max(0, i - 1));       setAnimating(true); window.setTimeout(()=>setAnimating(false),700); }
     };
@@ -174,7 +174,7 @@ export default function Startseite() {
     window.addEventListener('wheel', onWheel, { passive: false });
     window.addEventListener('keydown', onKey);
     return () => {
-      window.removeEventListener('wheel', onWheel as any);
+      window.removeEventListener('wheel', onWheel);
       window.removeEventListener('keydown', onKey);
     };
   }, [isFullpage, isAnimating]);


### PR DESCRIPTION
## Summary
- enable vertical panning for slides and disable touch/drag on hero, feature, main, CTA and thumbnail images
- guard fullpage wheel and key handlers behind desktop checks
- tighten contact form parsing types to avoid `any`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899edc3177883249863c3bd8702327a