### PR TITLE
fix: improve viewport handling and image loading

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -35,6 +35,11 @@ h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-heading);
 }
 
+/* FIX: prevent horizontal scroll from long words/URLs */
+p, li {
+  overflow-wrap: anywhere;
+}
+
 /* Kein hartes height:100% auf html/body/#root -> vermeidet 1px-Gaps */
 html, body, #root {
   width: 100%;

--- a/src/pages/Leistungen.css
+++ b/src/pages/Leistungen.css
@@ -11,8 +11,9 @@
 }
 
 /* Fullpage Rahmen */
+/* FIX: replace 100vh with 100svh to account for mobile browser UI */
 .fullpage {
-  height: 100vh;
+  height: 100svh;
   overflow: hidden;
   position: relative;
 }
@@ -26,7 +27,8 @@
 /* Jede Slide */
 .fullpage .fullpage-slide {
   --nav-h: 80px;
-  --slide-h: calc(100vh - var(--nav-h));
+  /* FIX: dynamic viewport height for slide calculations */
+  --slide-h: calc(100svh - var(--nav-h));
   height: var(--slide-h);
   min-height: var(--slide-h);
   display: flex;

--- a/src/pages/Startseite.css
+++ b/src/pages/Startseite.css
@@ -1,6 +1,7 @@
+/* FIX: use dynamic viewport unit to avoid mobile 100vh issues */
 :root {
   --nav-h: 80px;
-  --slide-h: calc(100vh - var(--nav-h));
+  --slide-h: calc(100svh - var(--nav-h));
 }
 
 .container {
@@ -10,11 +11,13 @@
   padding: var(--space-md);
   background-color: transparent;
 }
-.startseite { min-height: 100vh; }
-.section { height: 100vh; }
+/* FIX: allow full height without iOS browser chrome jumps */
+.startseite { min-height: 100svh; }
+.section { height: 100svh; }
 
 /* Fullpage Desktop */
-.fullpage { height: 100vh; overflow: hidden; position: relative; }
+/* FIX: svh prevents cut off on mobile Safari */
+.fullpage { height: 100svh; overflow: hidden; position: relative; }
 .fullpage .slides { height: 100%; transition: transform 700ms ease; will-change: transform; }
 .fullpage .fullpage-slide {
   height: var(--slide-h);
@@ -29,9 +32,10 @@
 }
 
 /* Hero auf Startseite volle Höhe */
+/* FIX: respect dynamic viewport height */
 .fullpage-slide--start-hero {
-  height: 100vh !important;
-  min-height: 100vh !important;
+  height: 100svh !important;
+  min-height: 100svh !important;
   padding-top: 0 !important;
 }
 

--- a/src/pages/Startseite.tsx
+++ b/src/pages/Startseite.tsx
@@ -10,7 +10,13 @@ const Hero: React.FC = () => (
     aria-label="Hero"
   >
     <div className="hero-overlay" />
-    <img src="/image_001.png" alt="Metallbau Präzision" className="hero__img" />
+    {/* FIX: ensure hero loads immediately but doesn't block scrolling */}
+    <img
+      src="/image_001.png"
+      alt="Metallbau Präzision"
+      className="hero__img"
+      fetchPriority="high"
+    />
     <div className="hero__content container">
       <h1>Ihr Projekt in Stahl und Metall</h1>
       <p>
@@ -57,7 +63,8 @@ const Features: React.FC = () => {
             className={`feature reveal feature--${i + 1}`}
             aria-label={f.title}
           >
-            <img src={f.img} alt={f.title} className="feature__img" />
+            {/* FIX: defer offscreen feature images */}
+            <img src={f.img} alt={f.title} className="feature__img" loading="lazy" />
             <h3>{f.title}</h3>
             <p>{f.text}</p>
           </article>
@@ -79,7 +86,8 @@ const CTA: React.FC = () => (
         <Link to="/beratung" className="btn btn--accent-cta">Kontakt</Link>
       </div>
       <div className="cta__image-container">
-        <img src="/image_001.avif" alt="Unsere Leistungen" className="cta__image" />
+        {/* FIX: lazy-load CTA illustration */}
+        <img src="/image_001.avif" alt="Unsere Leistungen" className="cta__image" loading="lazy" />
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- replace `100vh` with `100svh` for stable mobile viewport height
- lazy load non-critical images and set hero fetch priority
- avoid horizontal scroll by wrapping long text

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a1eb8439c832487f4eb49a3aac8c9