### PR TITLE
fix: enable scrolling over images on mobile

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -94,10 +94,10 @@ img, svg, video, canvas {
   -webkit-user-drag: none;
   user-select: none;
   -webkit-tap-highlight-color: transparent;
+  pointer-events: none;
 }
 
 /* FIX: Decorative layers must not intercept touches */
-.hero__img,
 .hero-overlay {
   pointer-events: none;
 }

--- a/src/pages/Leistungen.tsx
+++ b/src/pages/Leistungen.tsx
@@ -95,7 +95,15 @@ const CategoryBlock = ({ id, title, texts, images, showInlineFooter }: CategoryB
     >
       <div className="service-inner">
         <div className="service-main">
-          {images[0] && <img className="main-image" src={images[0]} alt={`${title} Bild 1`} loading="lazy" />}
+          {images[0] && (
+            <img
+              className="main-image"
+              src={images[0]}
+              alt={`${title} Bild 1`}
+              loading="lazy"
+              draggable={false}
+            />
+          )}
           <div className="service-text">
             <h3 id={`${id}-heading`}>{title}</h3>
             {texts.map((t, i) => <p key={i}>{t}</p>)}
@@ -104,7 +112,13 @@ const CategoryBlock = ({ id, title, texts, images, showInlineFooter }: CategoryB
 
         <div className="thumbnail-row">
           {images.slice(1, 5).map((src, i) => (
-            <img key={src} src={src} alt={`${title} Bild ${i + 2}`} loading="lazy" />
+            <img
+              key={src}
+              src={src}
+              alt={`${title} Bild ${i + 2}`}
+              loading="lazy"
+              draggable={false}
+            />
           ))}
         </div>
       </div>

--- a/src/pages/MetallForm.tsx
+++ b/src/pages/MetallForm.tsx
@@ -26,6 +26,7 @@ export default function MetallForm() {
                 src="./image_002.jpg"
                 alt="Metallbau-Werkstatt mit Funkenflug beim Schweißen"
                 loading="lazy"
+                draggable={false}
               />
             </figure>
           </div>

--- a/src/pages/Startseite.tsx
+++ b/src/pages/Startseite.tsx
@@ -16,6 +16,7 @@ const Hero: React.FC = () => (
       alt="Metallbau Präzision"
       className="hero__img"
       fetchPriority="high"
+      draggable={false}
     />
     <div className="hero__content container">
       <h1>Ihr Projekt in Stahl und Metall</h1>
@@ -64,7 +65,13 @@ const Features: React.FC = () => {
             aria-label={f.title}
           >
             {/* FIX: defer offscreen feature images */}
-            <img src={f.img} alt={f.title} className="feature__img" loading="lazy" />
+            <img
+              src={f.img}
+              alt={f.title}
+              className="feature__img"
+              loading="lazy"
+              draggable={false}
+            />
             <h3>{f.title}</h3>
             <p>{f.text}</p>
           </article>
@@ -87,7 +94,13 @@ const CTA: React.FC = () => (
       </div>
       <div className="cta__image-container">
         {/* FIX: lazy-load CTA illustration */}
-        <img src="/image_001.avif" alt="Unsere Leistungen" className="cta__image" loading="lazy" />
+        <img
+          src="/image_001.avif"
+          alt="Unsere Leistungen"
+          className="cta__image"
+          loading="lazy"
+          draggable={false}
+        />
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- prevent images from intercepting first touch scroll on mobile by disabling pointer events and dragging
- mark hero, feature and service images as non-draggable so vertical scrolling works immediately

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a2b986ffc832496d2847f0e751941