### PR TITLE
fix: keep fullpage slides within viewport

### DIFF
--- a/src/pages/Leistungen.css
+++ b/src/pages/Leistungen.css
@@ -18,22 +18,17 @@
   will-change: transform;
 }
 
-/* Jede Slide */
+/* Jede Slide: übernimmt Clipping, kein innerer Scroll */
 .fullpage .fullpage-slide {
   height: var(--slide-h);
   min-height: var(--slide-h);
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  box-sizing: border-box;
+  padding: 2rem 0 1rem;
+  position: relative;
+  overflow: hidden; /* fallback for overflow: clip */
+  overflow: clip;
+  contain: layout paint;
   background: var(--color-bg);
-  /* vorher: padding-top: calc(var(--nav-h) + 3rem); */
-    padding-top: 3rem;                    /* nur noch optischer Abstand */
-    overflow: hidden;
-    overflow: clip;
-    position: relative;
-    contain: layout paint;
-  }
+}
 
 /* Letzte Slide mit Footer unten (Footer wird nach unten gedrückt) */
 .fullpage .fullpage-slide--with-footer {
@@ -88,19 +83,35 @@
 .service-text h3{ margin-bottom: 1rem; font-size: 2rem; }
 .service-text p { line-height: 1.65; font-size: 1.05rem; margin-bottom: .6rem; }
 
-.thumbnail-row{ display: flex; gap: .85rem; align-items: stretch; flex-wrap: wrap; overflow: hidden; }
+.thumbnail-row{ display: flex; gap: .85rem; align-items: stretch; flex-wrap: wrap; }
 .thumbnail-row img{ width: 240px; height: 155px; object-fit: cover; border-radius: 8px; }
+
+/* Fullpage: Layout enger & elastischer damit alles in eine Viewhöhe passt */
+.fullpage .service-inner { max-width:1080px; margin:0 auto; padding:0 1rem; display:flex; flex-direction:column; gap:.75rem; }
+.fullpage .service-main  { display:grid; grid-template-columns:minmax(0,640px) 1fr; gap:1rem; align-items:start; }
+.fullpage .service-text h3 { margin-bottom:.5rem; font-size: clamp(1.4rem, 2vw, 1.9rem); }
+.fullpage .service-text p  { margin-bottom:.35rem; line-height:1.5; font-size: clamp(.95rem, .9vw, 1.05rem); }
+
+.fullpage .main-image {
+  width:100%; height:auto;
+  max-height: clamp(220px, 42vh, 520px);
+  object-fit:cover; border-radius:12px;
+}
+
+.fullpage .thumbnail-row {
+  display:grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap:.6rem; justify-items:center; align-items:stretch;
+  max-width:900px; margin-inline:auto;
+}
+.fullpage .thumbnail-row img { width:100%; height:120px; object-fit:cover; border-radius:8px; }
 
 /* Responsive */
 @media (max-width:1024px){
-  .fullpage { height: auto; overflow: visible; padding-top: 0; }  /* Fullpage-Layout aus */
-  .slides   { transform: none !important; }
+  .fullpage { height: auto; overflow: visible; }  /* Fullpage-Layout aus */
+  .slides__inner { transform: none !important; }
 
-  .fullpage .fullpage-slide,
-  .fullpage .fullpage-slide--with-footer {
-    height: auto; min-height: unset;
-    padding-top: 0;                       /* Offset entfällt mobil */
-  }
+  .fullpage .fullpage-slide { height: auto; min-height: unset; padding-top: 0; overflow: visible; }
 
   .dots { display: none; }
   .leistungen-fullpage .app > footer { display: block !important; }
@@ -108,15 +119,8 @@
   .service-main{ flex-direction: column; gap: 1rem; align-items: stretch; text-align: left; }
   .service-text{ align-items: flex-start; }
   .main-image{ max-height: 380px; }
-  .service-text h3{ font-size: 1.75rem; }
-  .thumbnail-row img{ width: 220px; height: 145px; }
 
   .footer-inline { position: static; padding-top: 2rem; }
-}
-
-@media (max-width:768px){
-  .thumbnail-row{ flex-wrap: wrap; }
-  .thumbnail-row img{ width: calc(50% - .5rem); height: 140px; }
 }
 
 /* Ankeroffset für mobile Anker-Links */

--- a/src/pages/Leistungen.tsx
+++ b/src/pages/Leistungen.tsx
@@ -196,6 +196,7 @@ export default function Leistungen() {
       <div className="slides">
         <div
           className="slides__inner"
+          // transform on inner wrapper keeps outer overflow hidden
           style={isFullpage && index > 0 ? { transform: `translateY(calc(-${index} * var(--slide-h)))` } : undefined}
         >
           {categories.map((c, i) => (

--- a/src/pages/Startseite.css
+++ b/src/pages/Startseite.css
@@ -11,28 +11,29 @@
 .startseite { min-height: 100svh; }
 .section    { height: 100svh; }
 
-/* Fullpage Desktop */
+/* Fullpage Desktop
+   - outer wrappers handle clipping
+   - inner wrapper moves via transform */
 .fullpage { height: 100svh; overflow: hidden; position: relative; }
-.fullpage .slides { position: relative; overflow: hidden; height: 100%; }
+.fullpage .slides { height: 100%; overflow: hidden; position: relative; }
 .fullpage .slides__inner { height: 100%; transition: transform 700ms ease; will-change: transform; }
+/* each slide clips its own overflow so no browser scrollbar appears */
 .fullpage .fullpage-slide {
   height: var(--slide-h);
   min-height: var(--slide-h);
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  box-sizing: border-box;
-  background: var(--color-bg);
-  padding-top: 3rem;
-  overflow: hidden;
+  padding: 2rem 0 1rem;
+  position: relative;
+  overflow: hidden; /* fallback for browsers without overflow:clip */
   overflow: clip;
+  contain: layout paint; /* avoid layout leaks when scaling content */
+  background: var(--color-bg);
 }
 
-/* Hero volle Höhe */
-.fullpage-slide--start-hero {
-  height: 100svh !important;
-  min-height: 100svh !important;
-  padding-top: 0 !important;
+/* Hero takes full viewport height but doesn't overlap next slide */
+.fullpage .fullpage-slide--start-hero {
+  height: 100svh;
+  min-height: 100svh;
+  padding-top: 0;
 }
 
 /* Dots */
@@ -80,8 +81,9 @@
   max-width: 800px; padding: var(--space-md);
   text-align: center; background: none; color: white;
 }
-.hero__content h1 { font-size: 2.5rem; margin-bottom: 0.5rem; }
-.hero__content p  { font-size: 1.25rem; margin-bottom: 1rem; }
+/* clamp fonts so hero shrinks gracefully on small viewports */
+.hero__content h1 { font-size: clamp(2rem, 3vw, 3rem); margin-bottom: 0.5rem; }
+.hero__content p  { font-size: clamp(1rem, 1.5vw, 1.5rem); margin-bottom: 1rem; }
 
 /* Buttons */
 .btn {
@@ -97,30 +99,35 @@
 .btn--accent-cta { background-color: var(--color-accent); color: var(--color-text); width: fit-content; margin: 0 auto; }
 .btn--accent-cta:hover { transform: translateY(-3px); }
 
-/* Features */
+/* Features slide uses grid; spacing reduced so content fits in slide */
 .features {
-  padding: calc(var(--space-lg) * 2) var(--space-md);
+  padding: 0 var(--space-md);
   text-align: center;
   background-color: var(--color-bg);
   height: 100%;
-  display: flex; flex-direction: column; justify-content: center; align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
-.features h2 { font-size: 2rem; margin-bottom: 2rem; color: var(--color-text); }
-  .features__grid { display: grid; gap: 2rem; overflow: hidden; }
+.features h2 { font-size: clamp(1.6rem, 2vw, 2rem); margin-bottom: 1.5rem; color: var(--color-text); }
+.features__grid { display: grid; gap: 1rem; overflow: hidden; }
 .feature {
-  padding: var(--space-lg);
+  padding: var(--space-md);
   border-radius: 0.5rem;
   background: transparent;
   color: var(--color-text);
 }
+/* images shrink first to keep slide height */
 .feature__img {
   width: 100%;
-  height: 260px;
+  height: auto;
+  max-height: clamp(160px, 30vh, 260px);
   object-fit: cover;
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
   border-radius: 12px;
 }
-.feature h3 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+.feature h3 { font-size: clamp(1.2rem, 1.8vw, 1.5rem); margin-bottom: 0.5rem; }
 
 /* CTA mit Inline-Footer */
 .cta {
@@ -151,21 +158,11 @@
 .footer-inline .to-top { display: none !important; }
 
 /* Responsive */
-@media (min-width: 320px) {
-  .hero__content h1 { font-size: 2rem; }
-  .hero__content p  { font-size: 1rem; }
-}
-@media (min-width: 768px) {
-  .features__grid { grid-template-columns: repeat(3, 1fr); }
-}
-@media (min-width: 1024px) {
-  .hero__content h1 { font-size: 3rem; }
-  .hero__content p  { font-size: 1.5rem; }
-}
+/* grid auto-fit already handles desktop; only adjust layout on mobile */
 @media (max-width: 1024px) {
   .fullpage { height: auto; overflow: visible; }
   .slides__inner { transform: none !important; }
-  .fullpage .fullpage-slide { height: auto; min-height: unset; padding-top: 0; }
+  .fullpage .fullpage-slide { height: auto; min-height: unset; padding-top: 0; overflow: visible; }
   .dots { display: none; }
   .start-fullpage .app > footer { display: block !important; }
   .cta__inner { flex-wrap: wrap; gap: var(--space-md); }

--- a/src/pages/Startseite.tsx
+++ b/src/pages/Startseite.tsx
@@ -161,7 +161,7 @@ export default function Startseite() {
       window.removeEventListener('wheel', onWheel);
       window.removeEventListener('keydown', onKey);
     };
-  }, [isFullpage, isAnimating]);
+  }, [isFullpage, isAnimating, slides.length]);
 
   const handleDotClick = (i: number) => (e: React.MouseEvent) => {
     e.preventDefault();
@@ -191,6 +191,7 @@ export default function Startseite() {
       <div className="slides">
         <div
           className="slides__inner"
+          // only inner wrapper moves; outer keeps clipping to hide browser scrollbars
           style=
             {isFullpage && index > 0
               ? { transform: `translateY(calc(-${index} * var(--slide-h) - var(--nav-h)))` }


### PR DESCRIPTION
## Summary
- separate transform and clipping layers for fullpage navigation on home and services
- tighten slide layouts with clamped typography and auto-fit thumbnails so content fits one viewport

## Testing
- `npm run lint`
- `npm run test:visual` *(fails: Timed out waiting 120000ms from config.webServer)*

------
https://chatgpt.com/codex/tasks/task_e_689b01f5c89c8324a8f6ea68ff94cf14